### PR TITLE
Remove explicit dependency on requests.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pandas==1.3.5
 pyotp==2.7.0
-requests==2.31.0
 openpyxl==3.0.10
 setuptools~=65.5.1
 cloudscraper~=1.2.68


### PR DESCRIPTION
Removing explicit dependency on requests, since the project doesn't use it directly.
cloudscraper already depends on requests >= 2.9.2 so pip will install anyway, but this way dependabots won't bug you any more.