### PR TITLE
Make API accept default options for requests.sessions.Session.request().

### DIFF
--- a/peerberrypy/api.py
+++ b/peerberrypy/api.py
@@ -25,6 +25,7 @@ class API:
             password: Optional[str] = None,
             tfa_secret: Optional[str] = None,
             access_token: Optional[str] = None,
+            request_opts: Optional[dict] = None,
     ):
         """
         Peerberry API wrapper with all relevant Peerberry functionalities.
@@ -33,6 +34,7 @@ class API:
         :param tfa_secret: Base32 secret used for two-factor authentication
         :param access_token: Access token used to authenticate to the API (Optional; Only pass the JWT for it to work!)
         (Only mandatory if account has two-factor authentication enabled)
+        :param request_opts: Optional[dict] - Additional options for :any:`requests.sessions.Session.request()`.
         """
 
         self.email = email
@@ -40,7 +42,7 @@ class API:
         self._tfa_secret = tfa_secret
 
         # Initialize HTTP session & authenticate to API
-        self._session = RequestHandler()
+        self._session = RequestHandler(request_opts or {})
         self.access_token = access_token
 
         if not access_token:

--- a/peerberrypy/request_handler.py
+++ b/peerberrypy/request_handler.py
@@ -5,7 +5,7 @@ import cloudscraper
 
 
 class RequestHandler:
-    def __init__(self):
+    def __init__(self, request_params: dict):
         """ Request handler for internal use with Peerberry's specifications. """
         self.__session = cloudscraper.create_scraper(
             browser={
@@ -14,6 +14,7 @@ class RequestHandler:
                 'desktop': True,
             }
         )
+        self._request_params = request_params
 
     def request(
             self,
@@ -29,10 +30,13 @@ class RequestHandler:
         if output_type not in output_types:
             raise ValueError(f'Output type must be one of the following: {", ".join(output_types)}')
 
+        requests_params = self._request_params.copy()
+        requests_params.update(kwargs)
+
         response = self.__session.request(
             method=method,
             url=url,
-            **kwargs,
+            **requests_params,
         )
 
         if response.status_code >= 400:


### PR DESCRIPTION
I want to set request timeout. The [requests documentation](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts) says all production code should have it defined (by default there is none) but I'm not sure a good default value. Docs says it should be slightly larger than a multiply of 3 (seconds), but then they give examples of 3.05 and 5...
The value I see often the wild is 30, but I think a smaller value would be more appropriate here.