### PR TITLE
Add 3 more API methods from the investor overview group.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Investor/portfolio data functions:
   get_overview -> Gets portfolio overview (Balance, total invested, total profit, net annual return, etc.).
   get_profit_overview -> Gets portfolio's profit on a daily, monthly or yearly basis (Data used in your profile's profit chart).
   get_investment_status -> Gets percentage of funds in different investment statuses (Current, late by 1-15 days, 16-30 days, and 31-60 days).
+  get_overview_originators -> Gets originators overview for portfolio.
+  get_overview_investment_types -> Gets investment types overview for portfolio.
+  get_overview_countries -> Gets country overview for portfolio.
  
 Marketplace/loan data functions:
   get_loans & get_loans_page -> Gets loans available for investment in the Peerberry marketplace according to the filters you specify. get_loans_page also returns metadata.

--- a/peerberrypy/api.py
+++ b/peerberrypy/api.py
@@ -147,6 +147,64 @@ class API:
         import pandas as pd
         return pd.DataFrame(investment_status)
 
+    def get_overview_originators(
+            self,
+            raw: bool = False,
+    ) -> 'Union[pd.DataFrame, list]':
+        """
+        :param raw: Returns python list if True or pandas DataFrame if False (False by default)
+        :return: Originators overview for portfolio
+        """
+
+        overview_originators = Utils.parse_peerberry_items(self._session.request(
+            url=f'{ENDPOINTS.ORIGINATORS_OVERVIEW_URI}',
+        ))
+
+        if raw:
+            return overview_originators
+
+        import pandas as pd
+        return pd.DataFrame(overview_originators)
+
+    def get_overview_investment_types(
+            self,
+            raw: bool = False,
+    ) -> 'Union[pd.DataFrame, list]':
+        """
+        :param raw: Returns python list if True or pandas DataFrame if False (False by default)
+        :return: Investment types overview for portfolio
+        """
+
+        investment_types = Utils.parse_peerberry_items(self._session.request(
+            url=f'{ENDPOINTS.INVESTMENT_TYPES_OVERVIEW_URI}',
+        ))
+
+        if raw:
+            return investment_types
+
+        import pandas as pd
+        return pd.DataFrame(investment_types)
+
+    def get_overview_countries(
+            self,
+            raw: bool = False,
+    ) -> 'Union[pd.DataFrame, list]':
+        """
+        :param raw: Returns python list if True or pandas DataFrame if False (False by default)
+        :return: Country overview for portfolio
+        """
+
+        overview_countries = Utils.parse_peerberry_items(self._session.request(
+            url=f'{ENDPOINTS.COUNTRIES_OVERVIEW_URI}',
+        ))
+
+
+        if raw:
+            return overview_countries
+
+        import pandas as pd
+        return pd.DataFrame(overview_countries)
+        
     def get_loans(
             self,
             quantity: int,

--- a/peerberrypy/api.py
+++ b/peerberrypy/api.py
@@ -55,6 +55,7 @@ class API:
 
         self.login()
 
+
     def get_profile(self) -> dict:
         """
         :return: Basic information, accounts & balance information
@@ -87,6 +88,7 @@ class API:
             'min_amount': top_available_tier['minAmount'],
         }
 
+
     def get_overview(self) -> dict:
         """
         :return: Available balance, total invested, total profit, current investments, net annual return, etc.
@@ -95,6 +97,7 @@ class API:
         return Utils.parse_peerberry_items(self._session.request(
             url=ENDPOINTS.OVERVIEW_URI
         ))
+
 
     def get_profit_overview(
             self,
@@ -147,6 +150,7 @@ class API:
         import pandas as pd
         return pd.DataFrame(investment_status)
 
+    
     def get_overview_originators(
             self,
             raw: bool = False,
@@ -166,6 +170,7 @@ class API:
         import pandas as pd
         return pd.DataFrame(overview_originators)
 
+
     def get_overview_investment_types(
             self,
             raw: bool = False,
@@ -184,6 +189,7 @@ class API:
 
         import pandas as pd
         return pd.DataFrame(investment_types)
+
 
     def get_overview_countries(
             self,
@@ -205,6 +211,7 @@ class API:
         import pandas as pd
         return pd.DataFrame(overview_countries)
         
+
     def get_loans(
             self,
             quantity: int,
@@ -276,6 +283,7 @@ class API:
 
         import pandas as pd
         return pd.DataFrame(loans)
+
 
     def get_loans_page(
             self,
@@ -394,6 +402,7 @@ class API:
             params=loan_params,
         )
 
+
     def get_loan_details(
             self,
             loan_id: int,
@@ -426,6 +435,7 @@ class API:
 
         return loan_details
 
+
     def get_agreement(self, loan_id: int, lang: str = 'en') -> bytes:
         """
         :param loan_id: ID of investment to get agreement of
@@ -439,6 +449,7 @@ class API:
         )
 
         return agreement_bytes
+
 
     def purchase_loan(
             self,
@@ -457,6 +468,7 @@ class API:
             data={'amount': str(amount)},
             exception_type=InsufficientFunds,
         )
+
 
     def get_investments(
             self,
@@ -562,6 +574,7 @@ class API:
         import pandas as pd
         return pd.DataFrame(investments_data['data'])
 
+
     def get_mass_investments(
             self,
             quantity: int = 100000000000,
@@ -623,6 +636,7 @@ class API:
             sheet_name=0,
         ).sort_values(by=sort, ascending=ascending_sort)[0:quantity]
 
+
     def get_account_summary(
             self,
             start_date: date,
@@ -660,6 +674,7 @@ class API:
             },
             'currency': summary_data.get('currency'),
         }
+
 
     def get_transactions(
             self,
@@ -721,6 +736,7 @@ class API:
 
         import pandas as pd
         return pd.DataFrame(transactions_data)
+
 
     def get_mass_transactions(
             self,
@@ -795,6 +811,7 @@ class API:
         ).sort_values(by=sort, ascending=ascending_sort)
         return parsed_transactions_data[0:quantity]
 
+
     def login(self) -> str:
         """
         :return: Access token to authenticate to Peerberry API
@@ -852,6 +869,7 @@ class API:
         # Set authorization header with JWT bearer token
         return f'Bearer {self.access_token}'
 
+
     def logout(self) -> str:
         """
         :return: Success message upon logging out.
@@ -868,9 +886,11 @@ class API:
 
         return 'Successfully logged out.'
 
+
     @staticmethod
     def get_countries() -> dict:
         return CONSTANTS.get_countries()
+
 
     @staticmethod
     def get_originators() -> dict:

--- a/peerberrypy/api.py
+++ b/peerberrypy/api.py
@@ -126,14 +126,26 @@ class API:
         import pandas as pd
         return pd.DataFrame(profit_overview)
 
-    def get_investment_status(self) -> dict:
+
+    def get_investment_status(
+            self,
+            raw: bool = False,
+    ) -> 'Union[pd.DataFrame, list]':
+
         """
+        :param raw: Returns python list if True or pandas DataFrame if False (False by default)
         :return: Percentage of funds in current loans and late loans (In 1-15, 16-30, and 31-60 day intervals)
         """
 
         investment_status = Utils.parse_peerberry_items(self._session.request(
             url=ENDPOINTS.INVESTMENTS_STATUS_URI
         ))
+
+        if raw:
+            return investment_status
+
+        import pandas as pd
+        return pd.DataFrame(investment_status)
 
     def get_loans(
             self,

--- a/peerberrypy/api.py
+++ b/peerberrypy/api.py
@@ -351,15 +351,22 @@ class API:
             url=f'{ENDPOINTS.LOANS_URI}/{loan_id}',
         ))
 
+        loan_details = {
+            'borrower': credit_data.get('borrower'),
+            'loan': credit_data.get('loan'),
+            'originator': credit_data.get('originator'),
+            'pledge': credit_data.get('pledge')
+        }
+
         schedule_data = credit_data['schedule']['data']
 
-        return {
-            'borrower_data': credit_data.get('borrower'),
-            'loan_data': credit_data.get('loan'),
-            'originator': credit_data.get('originator'),
-            'pledge': credit_data.get('pledge'),
-            'schedule_data': schedule_data if raw else pd.DataFrame(schedule_data),
-        }
+        if raw:
+            loan_details['schedule_data'] = schedule_data
+        else:
+            import pandas as pd
+            loan_details['schedule_data'] = pd.DataFrame(schedule_data)
+
+        return loan_details
 
     def get_agreement(self, loan_id: int, lang: str = 'en') -> bytes:
         """

--- a/peerberrypy/api.py
+++ b/peerberrypy/api.py
@@ -60,7 +60,10 @@ class API:
         :return: Basic information, accounts & balance information
         """
 
-        return Utils.parse_peerberry_items(self._session.request(url=ENDPOINTS.PROFILE_URI))
+        return Utils.parse_peerberry_items(self._session.request(
+            url=ENDPOINTS.PROFILE_URI
+        ))
+
 
     def get_loyalty_tier(self) -> dict:
         """
@@ -89,11 +92,9 @@ class API:
         :return: Available balance, total invested, total profit, current investments, net annual return, etc.
         """
 
-        return Utils.parse_peerberry_items(
-            self._session.request(
-                url=ENDPOINTS.OVERVIEW_URI,
-            )
-        )
+        return Utils.parse_peerberry_items(self._session.request(
+            url=ENDPOINTS.OVERVIEW_URI
+        ))
 
     def get_profit_overview(
             self,
@@ -115,10 +116,10 @@ class API:
         if periodicity not in periodicities:
             raise InvalidPeriodicity(f'Periodicity must be one of the following: {", ".join(periodicities)}')
 
-        profit_overview = self._session.request(
+        profit_overview = Utils.parse_peerberry_items(self._session.request(
             url=f'{ENDPOINTS.PROFIT_OVERVIEW_URI}/{start_date}/{end_date}/{periodicity}',
-        )
-
+        ))
+        
         if raw:
             return profit_overview
 
@@ -130,7 +131,9 @@ class API:
         :return: Percentage of funds in current loans and late loans (In 1-15, 16-30, and 31-60 day intervals)
         """
 
-        return Utils.parse_peerberry_items(self._session.request(url=ENDPOINTS.INVESTMENTS_STATUS_URI))
+        investment_status = Utils.parse_peerberry_items(self._session.request(
+            url=ENDPOINTS.INVESTMENTS_STATUS_URI
+        ))
 
     def get_loans(
             self,
@@ -332,9 +335,9 @@ class API:
         :return: The borrower's data, the loan's data, and the repayment schedule
         """
 
-        credit_data = self._session.request(
+        credit_data = Utils.parse_peerberry_items(self._session.request(
             url=f'{ENDPOINTS.LOANS_URI}/{loan_id}',
-        )
+        ))
 
         schedule_data = credit_data['schedule']['data']
 

--- a/peerberrypy/endpoints.py
+++ b/peerberrypy/endpoints.py
@@ -7,6 +7,10 @@ class ENDPOINTS:
 
     OVERVIEW_URI = f'{BASE_URI}/v1/investor/overview'
     PROFIT_OVERVIEW_URI = f'{BASE_URI}/v1/investor/overview/profit'
+    INVESTMENT_TYPES_OVERVIEW_URI = f'{BASE_URI}/v1/investor/overview/investment_types'
+    ORIGINATORS_OVERVIEW_URI = f'{BASE_URI}/v1/investor/overview/originators'
+    COUNTRIES_OVERVIEW_URI = f'{BASE_URI}/v1/investor/overview/countries'
+    
     LOYALTY_URI = f'{BASE_URI}/v1/investor/loyalty'
 
     INVESTMENTS_STATUS_URI = f'{BASE_URI}/v2/investor/overview/investment_statuses/current'

--- a/peerberrypy/utils.py
+++ b/peerberrypy/utils.py
@@ -4,28 +4,23 @@ from decimal import Decimal, DecimalException
 
 class Utils:
     @staticmethod
-    def parse_peerberry_items(__obj: dict) -> dict:
-        parsed_obj = copy.deepcopy(__obj)
-
-        for k, v in __obj.items():
-            if isinstance(v, dict):
-                nested_obj = {}
-
-                for k1, v1 in v.items():
-                    try:
-                        nested_obj[k1] = Decimal.from_float(v1) if isinstance(v1, float) else Decimal(v1)
-
-                    except (ValueError, TypeError, DecimalException):
-                        parsed_obj[k1] = v1
-
-                parsed_obj[k] = nested_obj
-
-                continue
-
+    def parse_peerberry_items(obj: dict) -> dict:
+        """Parse string represenations of decimals and floats into Decimal"""
+        if isinstance(obj, list):
+            return [Utils.parse_peerberry_items(item) for item in obj]
+        elif isinstance(obj, dict):
+            return {k: Utils.parse_peerberry_items(v) for k, v in obj.items()}
+        elif isinstance(obj, (Decimal, int)):
+            return obj
+        elif isinstance(obj, float):
+            return Decimal.from_float(obj)
+        elif isinstance(obj, str) and obj.startswith('+'):
+            # preserve phone numbers
+            return obj
+        else:
             try:
-                parsed_obj[k] = Decimal.from_float(v) if isinstance(v, float) else Decimal(v)
-
+                return Decimal(obj)
             except (ValueError, TypeError, DecimalException):
-                parsed_obj[k] = v
+                pass
 
-        return parsed_obj
+        return obj


### PR DESCRIPTION
Added 3 API methods related to the overview: get_overview_originators(), get_overview_investment_types(), get_overview_countries().
No tests added (sorry I’m new to Python unittests and could not get them to run) :-/

Changes breaking the backwards compatibility:

- Add raw mode (return pandas df) to get_investment_status() (because of default=False).
- Add late pandas import to get_loan_details(). Cleanup usage of "_data" in return object attributes.

Changes conflict with recent pull request done in parallel. I refactored the conflicting part:

- Endpoint URL “/v1/investor/overview/originators” belongs to “/investor” section, not to “/investments”, according to the API structure.
- Breaking change: INVESTMENTS_ORIGINATORS_URI  ORIGINATORS_OVERVIEW_URI
- Breaking change: get_investment_originators_overview()  get_overview_originators()
- I added the new Utils.parse_peerberry_originators() from the parallel PR to my get_overview_originators() to not have another breaking change, but I would prefer to do the list->dict conversion on the application side. Other requests also return lists.

Let me know what you think. Thanks for creating this lib!
